### PR TITLE
fix: removed USD as conversion option to prevent error

### DIFF
--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -47,7 +47,9 @@ fetch(`https://api.frankfurter.app/currencies`)
   .then((data) => {
     const entries = Object.entries(data);
     entries.forEach((entry) => {
-      currency[0].innerHTML += `<option value="${entry[0]}">${entry[0]}</option>`;
+      if (entry[0] !== 'USD') {
+        currency[0].innerHTML += `<option value="${entry[0]}">${entry[0]}</option>`;
+        }
     })
   })
   .catch(error => alert(`${error.message}`));


### PR DESCRIPTION
What I did:

-removed USD as conversion option since it's the default value (no chance for error)

Did this break anything?
- [x] No
- [ ] Yes

Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor(DRY-ing up/ reorganizing code, etc.)
- [ ] Super small fix (Corrected a typo, removed a comment, etc.)
- [x] Skip all the other stuff and briefly explain the fix.

Checklist:
- [ ] If this code needs to be tested, all tests are passing
- [ ] The code runs locally
- [ ] There are comments where clarification/ organization is needed
- [ ] The code is DRY. If it's not, I tried my best
- [ ] I reviewed my code before pushing

What's next?
